### PR TITLE
Add local docs preview for IBM contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ First, install the below software:
 1. [Node.js](https://nodejs.org/en). If you expect to use JavaScript in other projects, consider using [NVM](https://github.com/nvm-sh/nvm). Otherwise, consider using [Homebrew](https://formulae.brew.sh/formula/node) or installing [Node.js directly](https://nodejs.org/en).
 2. [IBM Cloud command line](https://cloud.ibm.com/docs/cli?topic=cli-getting-started)
 3. [Docker](https://www.docker.com). You must also ensure that it is running.
-   * You can alternatively use [Colima](https://github.com/abiosoft/colima) or [Rancher Desktop](https://rancherdesktop.io). When installing Rancher Desktop, choose Moby/Dockerd as the engine, rather than nerdctl. To ensure it's running, open up the app "Rancher Desktop". 
+   * You can use [Colima](https://github.com/abiosoft/colima) or [Rancher Desktop](https://rancherdesktop.io). When installing Rancher Desktop, choose Moby/Dockerd as the engine, rather than nerdctl. To ensure it's running, open up the app "Rancher Desktop". 
 
 Set up IBM Cloud to access the Docker image:
 

--- a/README.md
+++ b/README.md
@@ -8,15 +8,30 @@ The documentation content home for https://docs.quantum-computing.ibm.com. Refer
 
 These tools will also run in CI. But, it can be convenient when iterating to run the tools locally.
 
-First, install the below:
+Currently, this workflow only works for IBM maintainers. We are prioritizing fixing this workflow so that anyone can run the tools locally, tracked by https://github.com/Qiskit/docs/issues/53.
+
+First, install the below software:
 
 1. [Node.js](https://nodejs.org/en). If you expect to use JavaScript in other projects, consider using [NVM](https://github.com/nvm-sh/nvm). Otherwise, consider using [Homebrew](https://formulae.brew.sh/formula/node) or installing [Node.js directly](https://nodejs.org/en).
+2. [IBM Cloud command line](https://cloud.ibm.com/docs/cli?topic=cli-getting-started)
+3. [Docker](https://www.docker.com). You must also ensure that it is running.
+   * If you cannot install Docker Desktop (such as IBM contributors), you can use [Colima](https://github.com/abiosoft/colima) or [Rancher Desktop](https://rancherdesktop.io). When installing Rancher Desktop, choose Moby/Dockerd as the engine, rather than nerdctl. To ensure it's running, open up the app "Rancher Desktop". 
 
-Then, install the dependencies with:
+Set up IBM Cloud to access the Docker image:
+
+1. `ibmcloud plugin install cr`
+2. `ibmcloud cr region-set global`
+3. Make sure Docker is running, then `ibmcloud cr login`
+
+Finally, install the dependencies with:
 
 ```bash
 npm install
 ```
+
+## Preview the docs locally
+
+Run `./start` in your terminal, then open http://localhost:3000 in your browser.
 
 ## Spellcheck
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ First, install the below software:
 1. [Node.js](https://nodejs.org/en). If you expect to use JavaScript in other projects, consider using [NVM](https://github.com/nvm-sh/nvm). Otherwise, consider using [Homebrew](https://formulae.brew.sh/formula/node) or installing [Node.js directly](https://nodejs.org/en).
 2. [IBM Cloud command line](https://cloud.ibm.com/docs/cli?topic=cli-getting-started)
 3. [Docker](https://www.docker.com). You must also ensure that it is running.
-   * If you cannot install Docker Desktop (such as IBM contributors), you can use [Colima](https://github.com/abiosoft/colima) or [Rancher Desktop](https://rancherdesktop.io). When installing Rancher Desktop, choose Moby/Dockerd as the engine, rather than nerdctl. To ensure it's running, open up the app "Rancher Desktop". 
+   * You can alternatively use [Colima](https://github.com/abiosoft/colima) or [Rancher Desktop](https://rancherdesktop.io). When installing Rancher Desktop, choose Moby/Dockerd as the engine, rather than nerdctl. To ensure it's running, open up the app "Rancher Desktop". 
 
 Set up IBM Cloud to access the Docker image:
 

--- a/start
+++ b/start
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+docker run \
+  -v "$(pwd)"/docs:/home/node/app/docs \
+  -v "$(pwd)"/public/images:/home/node/app/public/images \
+  -p 3000:3000 \
+  -p 5001:5001 \
+  icr.io/quantum-computing/iqp-channel-docs-dev

--- a/start
+++ b/start
@@ -1,4 +1,15 @@
 #!/usr/bin/env sh
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
 
 docker run \
   -v "$(pwd)"/docs:/home/node/app/docs \


### PR DESCRIPTION
Closes https://github.com/Qiskit/docs/issues/1. Running `./start` will open up the One Docs app at localhost:3000 using content from the local repository.

Currently, you have to log into IBM Cloud and have the correct permissions. We will improve this with https://github.com/Qiskit/docs/issues/53.

